### PR TITLE
fixed buffer overflow in qtewin.cpp

### DIFF
--- a/uiports/qtewin.cpp
+++ b/uiports/qtewin.cpp
@@ -2366,6 +2366,10 @@ int parse_parameters(int in_argc, char ** in_argv)
 
   for (i = 1; i < in_argc; i++)
   {
+    /* check in_argv[i] buffer size, ignore if too large */
+    if (strlen(in_argv[i] > sizeof(g_server))
+        continue;
+
     strcpy(g_server, in_argv[i]);
     if (strcmp(in_argv[i], "-h") == 0)
     {


### PR DESCRIPTION
The source file qtewin.cpp uses strcpy() directly from argv[] input into a 64 byte buffer. This adds a check that will ignore input larger than the buffer. You can also reject to start the program instead, depending on preference.

Only 1 commit, 1 file changed.