### PR TITLE
Allow workspaces to be switched

### DIFF
--- a/xkeymap.c
+++ b/xkeymap.c
@@ -636,6 +636,24 @@ handle_special_keys(uint32 keysym, unsigned int state, uint32 ev_time, RD_BOOL p
 {
 	switch (keysym)
 	{
+		case XK_Left:
+		case XK_Right:
+		case XK_Tab:
+			if ((get_key_state(state, XK_Alt_L) || get_key_state(state, XK_Alt_R))
+				&& (get_key_state(state, XK_Control_L)
+				|| get_key_state(state, XK_Control_R)))
+			{
+				/* Ctrl-Alt-Left/Right/Tab:
+				* Ungrab the keyboard so that user can use Windows manager's hot keys */
+				extern RD_BOOL g_fullscreen;
+				if (g_fullscreen) { /* Turn to normal window. Otherwise, rdesktop will be always on top */
+					xwin_toggle_fullscreen();
+				}
+				XUngrabKeyboard(g_display, CurrentTime);
+				return True;
+			}
+			break;
+
 		case XK_Return:
 			if ((get_key_state(state, XK_Alt_L) || get_key_state(state, XK_Alt_R))
 			    && (get_key_state(state, XK_Control_L)


### PR DESCRIPTION
theres a bunch of people who would like to be able to switch workspaces while using rdesktop
https://bugs.launchpad.net/ubuntu/+source/rdesktop/+bug/861789
http://ubuntuforums.org/showthread.php?t=954887

this patch was originally proposed in 2009 but never got implemented
http://sourceforge.net/p/rdesktop/patches/178/

i think it's really useful ...

originally done by sunner for version rdesktop-1.6.0
http://blog.sunner.cn/rdesktop-patch-switch-local-workspaces-and-windows-by-local-hot-keys/

Double press Ctrl+Alt+Left or Ctrl+Alt+Right to switch local active workspaces.
Double press Ctrl+Alt+Tab to switch local active window.
Other hot keys are sent directly to remote machine.
If using -fD options and having two or above workspaces, the effect is amazing!
If rdesktop is running in fullscreen mode (-f and without -D), Ctrl+Alt+Left/Right/Tab will toggle it to window mode first. After switching back, it can NOT toggle to fullscreen automatically. Press Ctrl+Alt+Enter to do that. (I know this is boring. But it is the best I can do. Rdesktop use override_redirect to implement fullscreen which makes it always the top-most window no matter which workspace/window you have switched to)
