### PR TITLE
Factor out event wallclock time acquisition

### DIFF
--- a/doc/rdesktop.1
+++ b/doc/rdesktop.1
@@ -123,6 +123,12 @@ but everything after this is unencrypted (including interactive logins).
 Do not send mouse motion events.  This saves bandwidth, although some Windows
 applications may rely on receiving mouse motion.
 .TP
+.TP
+.BR "-M <interval>"
+Send keepalive mouse motion events every <interval> seconds.  This prevents
+the server from timing out the session due to inactivity, and in the process
+terminating potentially important non-interactive programs.
+.TP
 .BR "-C"
 Use private colourmap.  This will improve colour accuracy on an 8-bit display,
 but rdesktop will appear in false colour when not focused.

--- a/rdesktop.c
+++ b/rdesktop.c
@@ -154,6 +154,8 @@ extern RDPDR_DEVICE g_rdpdr_device[];
 extern uint32 g_num_devices;
 extern char *g_rdpdr_clientname;
 
+extern uint32 keepalive_interval;
+
 #ifdef RDP2VNC
 extern int rfb_port;
 extern int defer_time;
@@ -171,6 +173,7 @@ usage(char *program)
 	fprintf(stderr, "See http://www.rdesktop.org/ for more information.\n\n");
 
 	fprintf(stderr, "Usage: %s [options] server[:port]\n", program);
+	fprintf(stderr, "   -M: send keepalive mouse motion events every n seconds\n");
 #ifdef RDP2VNC
 	fprintf(stderr, "   -V: vnc port\n");
 	fprintf(stderr, "   -Q: defer time (ms)\n");
@@ -571,10 +574,14 @@ main(int argc, char *argv[])
 #define VNCOPT
 #endif
 	while ((c = getopt(argc, argv,
-			   VNCOPT "A:u:L:d:s:c:p:n:k:g:o:fbBeEitmzCDKS:T:NX:a:x:Pr:045h?")) != -1)
+			   VNCOPT "A:M:u:L:d:s:c:p:n:k:g:o:fbBeEitmzCDKS:T:NX:a:x:Pr:045h?")) != -1)
 	{
 		switch (c)
 		{
+			case 'M':
+				keepalive_interval = strtoul(optarg, NULL, 10);
+				break;
+
 #ifdef RDP2VNC
 			case 'V':
 				rfb_port = strtol(optarg, NULL, 10);


### PR DESCRIPTION
Instead of calling 'time(NULL)' from multiple places across the
event loop, compute 'ev_time' once for each event before handling
the event type. Also, pass 'ev_time' into 'handle_button_event()'
for the same reason.
This would make for a slightly cleaner and more efficient event
loop.
---
PS. I've given up on trying to push a mouse-wiggler feature (for which this patch was
a precursor cleanup step), but thinking about it, this should be a genuinely positive
change for rdesktop in and of itself, orthogonally to the previous rejected pull request :)

Please consider applying just this individual patch. Thanks,
--Gabriel