### PR TITLE
Revert "Support horizontal scroll with mouse wheel"

### DIFF
--- a/constants.h
+++ b/constants.h
@@ -245,8 +245,6 @@ enum RDP_INPUT_DEVICE
 #define MOUSE_FLAG_BUTTON3      0x4000
 #define MOUSE_FLAG_BUTTON4      0x0280
 #define MOUSE_FLAG_BUTTON5      0x0380
-#define MOUSE_FLAG_BUTTON6      0x0580
-#define MOUSE_FLAG_BUTTON7      0x0480
 #define MOUSE_FLAG_DOWN         0x8000
 
 /* Raster operation masks */

--- a/xkeymap.c
+++ b/xkeymap.c
@@ -889,10 +889,6 @@ xkeymap_translate_button(unsigned int button)
 			return MOUSE_FLAG_BUTTON4;
 		case Button5:	/* wheel down */
 			return MOUSE_FLAG_BUTTON5;
-		case 6:			/* wheel left */
-			return MOUSE_FLAG_BUTTON6;
-		case 7:			/* wheel right */
-			return MOUSE_FLAG_BUTTON7;
 	}
 
 	return 0;


### PR DESCRIPTION
Reverts rdesktop/rdesktop#78

This PR #78  is incomplete. Needs to check if RDP server has the horizontal wheel capabilities otherwise a send of these event will make server disconnect the client. Such as my test case against a 2008R2 RDP server.