### PR TITLE
rdesktop: Add TCP Keepalive switch

### DIFF
--- a/rdesktop.c
+++ b/rdesktop.c
@@ -574,7 +574,7 @@ main(int argc, char *argv[])
 #define VNCOPT
 #endif
 	while ((c = getopt(argc, argv,
-			   VNCOPT "A:u:L:J:d:s:c:p:n:k:g:o:fbBeEitmzCDKS:T:NX:a:x:Pr:045h?")) != -1)
+			   VNCOPT "A:u:L:d:s:c:p:n:k:g:o:fbBeEitmzCDKS:T:NX:a:x:Pr:045h?J")) != -1)
 	{
 		switch (c)
 		{

--- a/rdesktop.c
+++ b/rdesktop.c
@@ -105,6 +105,7 @@ RD_BOOL g_numlock_sync = False;
 RD_BOOL g_lspci_enabled = False;
 RD_BOOL g_owncolmap = False;
 RD_BOOL g_ownbackstore = True;	/* We can't rely on external BackingStore */
+RD_BOOL g_tcp_keepalive = False; /* By default, TCP Keepalive is off */
 RD_BOOL g_seamless_rdp = False;
 RD_BOOL g_use_password_as_pin = False;
 char g_seamless_shell[512];
@@ -189,6 +190,7 @@ usage(char *program)
 #endif
 	fprintf(stderr, "   -f: full-screen mode\n");
 	fprintf(stderr, "   -b: force bitmap updates\n");
+	fprintf(stderr, "   -J: Enable TCP Keepalive (SO_KEEPALIVE)\n");
 #ifdef HAVE_ICONV
 	fprintf(stderr, "   -L: local codepage\n");
 #endif
@@ -572,7 +574,7 @@ main(int argc, char *argv[])
 #define VNCOPT
 #endif
 	while ((c = getopt(argc, argv,
-			   VNCOPT "A:u:L:d:s:c:p:n:k:g:o:fbBeEitmzCDKS:T:NX:a:x:Pr:045h?")) != -1)
+			   VNCOPT "A:u:L:J:d:s:c:p:n:k:g:o:fbBeEitmzCDKS:T:NX:a:x:Pr:045h?")) != -1)
 	{
 		switch (c)
 		{
@@ -607,6 +609,10 @@ main(int argc, char *argv[])
 #else
 				error("iconv support not available\n");
 #endif
+				break;
+
+			case 'J':
+				g_tcp_keepalive = True;
 				break;
 
 			case 'd':

--- a/tcp.c
+++ b/tcp.c
@@ -68,6 +68,7 @@ int g_tcp_port_rdp = TCP_PORT_RDP;
 extern RD_BOOL g_user_quit;
 extern RD_BOOL g_network_error;
 extern RD_BOOL g_reconnect_loop;
+extern RD_BOOL g_tcp_keepalive;
 
 /* wait till socket is ready to write or timeout */
 static RD_BOOL
@@ -513,6 +514,14 @@ tcp_connect(char *server)
 				   option_len);
 		}
 	}
+
+	/* Did we enable TCP Keepalive? */
+	if (g_tcp_keepalive == True)
+	{
+		int tcp_keepalive = 1;
+		setsockopt(g_sock, SOL_SOCKET, SO_KEEPALIVE, &tcp_keepalive, sizeof(tcp_keepalive));
+	}
+
 
 	g_in.size = 4096;
 	g_in.data = (uint8 *) xmalloc(g_in.size);


### PR DESCRIPTION
Resolves Issue #84 

Added switch -J to enable TCP Keepalive in the client side, so it can
take advantage of TCP keeping session when traversing aggressive
firewalls.
By default it is disabled (current behaviour).
For more information on TCP Keepalive, please visit
http://tldp.org/HOWTO/TCP-Keepalive-HOWTO/overview.html

Signed-off-by: Rodrigo Freire <root@rf01.pro>