### PR TITLE
Send longer drive names for redirected drives

### DIFF
--- a/disk.c
+++ b/disk.c
@@ -3,6 +3,7 @@
    Disk Redirection
    Copyright (C) Jeroen Meijer <jeroen@oldambt7.com> 2003-2008
    Copyright 2003-2011 Peter Astrand <astrand@cendio.se> for Cendio AB
+   Copyright 2017 Karl Mikaelsson <derfian@cendio.se> for Cendio AB
 
    This program is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -315,6 +316,7 @@ disk_enum_devices(uint32 * id, char *optarg)
 	char *pos = optarg;
 	char *pos2;
 	int count = 0;
+	DISK_DEVICE *pdisk_data;
 
 	/* skip the first colon */
 	optarg++;
@@ -322,14 +324,16 @@ disk_enum_devices(uint32 * id, char *optarg)
 	{
 		pos2 = next_arg(optarg, '=');
 
+		pdisk_data = (DISK_DEVICE *) xmalloc(sizeof(DISK_DEVICE));
+		memset(pdisk_data, 0, sizeof(DISK_DEVICE));
+		strncpy(pdisk_data->name, optarg, sizeof(pdisk_data->name) - 1);
 		strncpy(g_rdpdr_device[*id].name, optarg, sizeof(g_rdpdr_device[*id].name) - 1);
-		if (strlen(optarg) > (sizeof(g_rdpdr_device[*id].name) - 1))
-			fprintf(stderr, "share name %s truncated to %s\n", optarg,
-				g_rdpdr_device[*id].name);
 
 		g_rdpdr_device[*id].local_path = (char *) xmalloc(strlen(pos2) + 1);
 		strcpy(g_rdpdr_device[*id].local_path, pos2);
 		g_rdpdr_device[*id].device_type = DEVICE_TYPE_DISK;
+		g_rdpdr_device[*id].pdevice_data = (void *) pdisk_data;
+
 		count++;
 		(*id)++;
 

--- a/types.h
+++ b/types.h
@@ -3,6 +3,7 @@
    Common data types
    Copyright (C) Matthew Chapman 1999-2008
    Copyright 2014 Henrik Andersson <hean01@cendio.se> for Cendio AB
+   Copyright 2017 Karl Mikaelsson <derfian@cendio.se> for Cendio AB
 
    This program is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -23,6 +24,10 @@ typedef int RD_BOOL;
 #ifndef True
 #define True  (1)
 #define False (0)
+#endif
+
+#ifndef PATH_MAX
+#define PATH_MAX 256
 #endif
 
 typedef unsigned char uint8;
@@ -222,6 +227,12 @@ typedef struct rdpdr_device_info
 }
 RDPDR_DEVICE;
 
+typedef struct rdpdr_disk_device_info
+{
+	char name[PATH_MAX];
+}
+DISK_DEVICE;
+
 typedef struct rdpdr_serial_device_info
 {
 	int dtr;
@@ -275,10 +286,6 @@ typedef struct notify_data
 	unsigned int num_entries;
 }
 NOTIFY;
-
-#ifndef PATH_MAX
-#define PATH_MAX 256
-#endif
 
 typedef struct fileinfo
 {


### PR DESCRIPTION
The RDP spec lies about Unicode support, but this will at least allow drive names longer than 7 characters.