### PR TITLE
rdesktop: Add TCP Keepalive switch

### DIFF
--- a/rdesktop.c
+++ b/rdesktop.c
@@ -574,7 +574,7 @@ main(int argc, char *argv[])
 #define VNCOPT
 #endif
 	while ((c = getopt(argc, argv,
-			   VNCOPT "A:u:L:J:d:s:c:p:n:k:g:o:fbBeEitmzCDKS:T:NX:a:x:Pr:045h?")) != -1)
+			   VNCOPT "A:u:L:d:s:c:p:n:k:g:o:fbBeEitmzCDKS:T:NX:a:x:Pr:045h?J")) != -1)
 	{
 		switch (c)
 		{

--- a/rdesktop.c
+++ b/rdesktop.c
@@ -105,6 +105,7 @@ RD_BOOL g_numlock_sync = False;
 RD_BOOL g_lspci_enabled = False;
 RD_BOOL g_owncolmap = False;
 RD_BOOL g_ownbackstore = True;	/* We can't rely on external BackingStore */
+RD_BOOL g_tcp_keepalive = False; /* By default, TCP Keepalive is off */
 RD_BOOL g_seamless_rdp = False;
 RD_BOOL g_use_password_as_pin = False;
 char g_seamless_shell[512];
@@ -189,6 +190,7 @@ usage(char *program)
 #endif
 	fprintf(stderr, "   -f: full-screen mode\n");
 	fprintf(stderr, "   -b: force bitmap updates\n");
+	fprintf(stderr, "   -J: Enable TCP Keepalive (SO_KEEPALIVE)\n");
 #ifdef HAVE_ICONV
 	fprintf(stderr, "   -L: local codepage\n");
 #endif
@@ -572,7 +574,7 @@ main(int argc, char *argv[])
 #define VNCOPT
 #endif
 	while ((c = getopt(argc, argv,
-			   VNCOPT "A:u:L:d:s:c:p:n:k:g:o:fbBeEitmzCDKS:T:NX:a:x:Pr:045h?")) != -1)
+			   VNCOPT "A:u:L:J:d:s:c:p:n:k:g:o:fbBeEitmzCDKS:T:NX:a:x:Pr:045h?")) != -1)
 	{
 		switch (c)
 		{
@@ -607,6 +609,10 @@ main(int argc, char *argv[])
 #else
 				error("iconv support not available\n");
 #endif
+				break;
+
+			case 'J':
+				g_tcp_keepalive = True;
 				break;
 
 			case 'd':

--- a/tcp.c
+++ b/tcp.c
@@ -68,6 +68,7 @@ int g_tcp_port_rdp = TCP_PORT_RDP;
 extern RD_BOOL g_user_quit;
 extern RD_BOOL g_network_error;
 extern RD_BOOL g_reconnect_loop;
+extern RD_BOOL g_tcp_keepalive;
 
 /* wait till socket is ready to write or timeout */
 static RD_BOOL
@@ -513,6 +514,14 @@ tcp_connect(char *server)
 				   option_len);
 		}
 	}
+
+	/* Did we enable TCP Keepalive? */
+	if (g_tcp_keepalive == True)
+	{
+		int tcp_keepalive = 1;
+		setsockopt(g_sock, SOL_SOCKET, SO_KEEPALIVE, &tcp_keepalive, sizeof(tcp_keepalive));
+	}
+
 
 	g_in.size = 4096;
 	g_in.data = (uint8 *) xmalloc(g_in.size);


### PR DESCRIPTION
Hi Henrik,

Resending again, with more information, for your consideration.

Of course; The keepalive can be set in the server too. Matter of fact, the keep-alive is configurable on *every* endpoint: Client or server. It is a `socket()` property. If the server does not enables `SO_KEEPALIVE`, the server will honour client-initiated keep-alive packets.

And the reverse is also true: If the server has `SO_KEEPALIVE` enabled but the client is not, the client will correctly reply the server's keepalive replies.

Please allow me add some more evidence so you can reconsider it. The following evidence was taken with a client compiled using the patch.

~~~
[rfreire@rf ~]$ rdesktop 192.168.122.83 &
[rfreire@rf ~]$ netstat -nto | grep 3389
tcp        0      0 192.168.122.1:39806         192.168.122.83:3389         ESTABLISHED off (0.00/0/0)
~~~

As you may see above, the client is not originating any keepalive; it will be completely dependent by Server's keepalive configuration.

Now see the below example:

~~~
[rfreire@rf ~]$ rdesktop -J 192.168.122.83 &
[rfreire@rf ~]$ netstat -nto | grep 3389
tcp        0      0 192.168.122.1:39818         192.168.122.83:3389         ESTABLISHED keepalive (2.41/0/0)
~~~

Now we have the keepalive enabled and the server will reply the **client's** keepalive settings.

What am I trying to fix here:

During the holidays season I was working using a different ISP, and in this ISP I was behind a [CGNAT](https://en.wikipedia.org/wiki/Carrier-grade_NAT).
The carrier NAT options were pretty aggressive; if the connection were idle for 5 minutes, the NAT entry was dropped at the carrier, and the connection lost to my remote Windows session.

Then, I rebuilt `rdesktop` adding keepalive settings and set some aggressive values, such as: 

~~~
net.ipv4.tcp_keepalive_time=120
net.ipv4.tcp_keepalive_probes=5
net.ipv4.tcp_keepalive_intvl=10
~~~

That means:

Results in the following behavior:

1. Trigger a keepalive probe every 120 seconds if the connection is busy
2. If the connection is idle, probe the remote host every 10 seconds
3. Close the connection after 5 failed probes

By using `rdesktop -J` and that more aggressive client-side keepalive settings, I was able to keep a stable  and persistent network connection.

For what is worth, Windows uses similar default values (check [this link](https://blogs.technet.microsoft.com/nettracer/2010/06/03/things-that-you-may-want-to-know-about-tcp-keepalives/)) as Linux and the [RFC recommendation](https://tools.ietf.org/html/rfc1122#page-101), which is:

1. Trigger a keepalive probe every 7200 seconds (2 hours)
2. If the connection is idle and the remote host does not reply, probe the remote host every 75 seconds
3. Close the connection after 9 failed probes

Which is, unfortunately, not enough for my scenario, due to the large item 1 timeout.

Thus, I kindly ask you to reconsider and merge.

My best regards,

- Rodrigo.