### PR TITLE
Workaround for key caching in OpenSSL > 1.1.0 ( fixes #118)

### DIFF
--- a/ssl.c
+++ b/ssl.c
@@ -161,6 +161,11 @@ rdssl_cert_to_rkey(RDSSL_CERT * cert, uint32 * key_len)
 	int nid;
 	int ret;
 
+	const unsigned char *p;
+	int pklen;
+
+	RSA *rsa = NULL;
+
 	/* By some reason, Microsoft sets the OID of the Public RSA key to
 	   the oid for "MD5 with RSA Encryption" instead of "RSA Encryption"
 
@@ -194,10 +199,35 @@ rdssl_cert_to_rkey(RDSSL_CERT * cert, uint32 * key_len)
 
 	if ((nid == NID_md5WithRSAEncryption) || (nid == NID_shaWithRSAEncryption))
 	{
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
 		logger(Protocol, Debug,
-		       "rdssl_cert_to_key(), re-setting algorithm type to RSA in server certificate");
+				"rdssl_cert_to_key(), re-setting algorithm type to RSA in server certificate");
 		X509_PUBKEY_set0_param(key, OBJ_nid2obj(NID_rsaEncryption), 0, NULL, NULL, 0);
+#else
+
+		if (!X509_PUBKEY_get0_param(NULL, &p, &pklen, NULL, key)) {
+			logger(Protocol, Error,
+					"rdssl_cert_to_key(), failed to get algorithm used for public key");
+			rdssl_log_ssl_errors("rdssl_cert_to_key()");
+
+			return NULL;
+		}
+
+		if (!(rsa = d2i_RSAPublicKey(NULL, &p, pklen))) {
+			logger(Protocol, Error,
+					"rdssl_cert_to_key(), failed to extract public key from certificate");
+			rdssl_log_ssl_errors("rdssl_cert_to_key()");
+
+			return NULL;
+		}
+
+		lkey = RSAPublicKey_dup(rsa);
+		*key_len = RSA_size(lkey);
+		return lkey;
+#endif
+
 	}
+
 	epk = X509_get_pubkey(cert);
 	if (NULL == epk)
 	{
@@ -256,7 +286,7 @@ rdssl_rkey_get_exp_mod(RDSSL_RKEY * rkey, uint8 * exponent, uint32 max_exp_len, 
 	e = rkey->e;
 	n = rkey->n;
 #else
-	RSA_get0_key(rkey, &e, &n, NULL);
+	RSA_get0_key(rkey, &n, &e, NULL);
 #endif
 
 	if ((BN_num_bytes(e) > (int) max_exp_len) || (BN_num_bytes(n) > (int) max_mod_len))


### PR DESCRIPTION
Since v.1.1.0 the key caching has been added to OpenSSL.
After X.509 had been parsed there is no point in changing of key
algorithm as the key had already been decoded and cached result will
be returned anyway. (check crypto/x509/x_pubkey.c: X509_PUBKEY_get0())

Basically all our attempts to change algorithm to RSAEncryption make no sense anymore as certificate has already been decoded and key was set to NULL.
Moreover, according to comments in https://github.com/openssl/openssl/blob/master/crypto/x509/x_pubkey.c#L151 this NULL key is left just to enqueue errors later.
We can fix this at least in four ways:

1) Ask OpenSSL devs for advice on how to bypass this behaviour
2) Patch  X509_PUBKEY_get0(). Something like this:

```c
EVP_PKEY *X509_PUBKEY_get0(X509_PUBKEY *key)
{
    int rv;
    EVP_PKEY *ret = NULL;

    if (key == NULL || key->public_key == NULL)
        return NULL;

    if (key->pkey != NULL)
        return key->pkey;

    /*
     * When the key ASN.1 is initially parsed an attempt is made to
     * decode the public key and cache the EVP_PKEY structure. If this
     * operation fails the cached value will be NULL. Parsing continues
     * to allow parsing of unknown key types or unsupported forms.
     * We repeat the decode operation so the appropriate errors are left
     * in the queue.
     */
    rv = x509_pubkey_decode(&ret, key);
    fprintf(stderr, "%s: rv = %d ret = %p\n", __func__, rv, ret);
    /* If decode doesn't fail something bad happened */
    if (rv == 0) {
        X509err(X509_F_X509_PUBKEY_GET0, ERR_R_INTERNAL_ERROR);
        EVP_PKEY_free(ret);
        return NULL;
    }

    if (ret != NULL) {
        //X509err(X509_F_X509_PUBKEY_GET0, ERR_R_INTERNAL_ERROR);
        key->pkey = ret;
        return key->pkey;
    }

    return NULL;
}
```

3) Use libtasn1 for parsing instead of OpenSSL.
4) Get the RSA public key using code from rsa_pub_decode() (https://github.com/openssl/openssl/blob/master/crypto/rsa/rsa_ameth.c#L95)

This PR implements the last variant.