### PR TITLE
Fix order of colour values in BGR and BGRA cursor types

### DIFF
--- a/xwin.c
+++ b/xwin.c
@@ -2944,12 +2944,12 @@ get_next_xor_pixel(uint8 * xormask, int bpp, int *k)
 			break;
 		case 24:
 			s8 = xormask + *k;
-			rv = (s8[0] << 16) | (s8[1] << 8) | s8[2];
+			rv = (s8[2] << 16) | (s8[1] << 8) | s8[0];
 			(*k) += 3;
 			break;
 		case 32:
 			s8 = xormask + *k;
-			rv = (s8[1] << 16) | (s8[2] << 8) | s8[3];
+			rv = (s8[2] << 16) | (s8[1] << 8) | s8[0];
 			(*k) += 4;
 			break;
 		default:


### PR DESCRIPTION
rdesktop has some problems rendering the cursors from xorgxrdp and some Windows systems.  One problem is this: the colour data is being interpreted the wrong way round.  The order of components for each pixel in a 32-bit cursor image is: B, G, R, A (this translates into ARGB when loaded as a little-endian 32-bit integer).  Currently rdesktop is getting this wrong by loading A as one of the colour values, so it merges the alpha channel with the G and R channels to produce the cursor.