### PR TITLE
Obey the Alpha instead of the AND-mask for 32bpp cursors

### DIFF
--- a/xwin.c
+++ b/xwin.c
@@ -2949,7 +2949,7 @@ get_next_xor_pixel(uint8 * xormask, int bpp, int *k)
 			break;
 		case 32:
 			s8 = xormask + *k;
-			rv = (s8[2] << 16) | (s8[1] << 8) | s8[0];
+			rv = (s8[3] << 24) | (s8[2] << 16) | (s8[1] << 8) | s8[0];
 			(*k) += 4;
 			break;
 		default:
@@ -3001,15 +3001,22 @@ ui_create_cursor(unsigned int x, unsigned int y, int width, int height,
 		{
 			for (nextbit = 0x80; nextbit != 0; nextbit >>= 1)
 			{
-				if (get_next_xor_pixel(xormask, bpp, &k))
+				unsigned int argb = get_next_xor_pixel(xormask, bpp, &k);
+				int andpixel = (*andmask) & nextbit;
+				if (bpp == 32)
 				{
-					*pcursor |= (~(*andmask) & nextbit);
+					andpixel=(argb>>24)>0xf0 ? 0 : 0xff;
+					argb &= 0xFFFFFF;
+				}
+				if (argb)
+				{
+					*pcursor |= (~andpixel & nextbit);
 					*pmask |= nextbit;
 				}
 				else
 				{
-					*pcursor |= ((*andmask) & nextbit);
-					*pmask |= (~(*andmask) & nextbit);
+					*pcursor |= (andpixel & nextbit);
+					*pmask |= (~andpixel & nextbit);
 				}
 			}
 

--- a/xwin.c
+++ b/xwin.c
@@ -2944,12 +2944,12 @@ get_next_xor_pixel(uint8 * xormask, int bpp, int *k)
 			break;
 		case 24:
 			s8 = xormask + *k;
-			rv = (s8[0] << 16) | (s8[1] << 8) | s8[2];
+			rv = (s8[2] << 16) | (s8[1] << 8) | s8[0];
 			(*k) += 3;
 			break;
 		case 32:
 			s8 = xormask + *k;
-			rv = (s8[1] << 16) | (s8[2] << 8) | s8[3];
+			rv = (s8[2] << 16) | (s8[1] << 8) | s8[0];
 			(*k) += 4;
 			break;
 		default:


### PR DESCRIPTION
(Following on from PR # 147)
rdesktop has some problems rendering the cursors from xorgxrdp and some Windows systems.  I am not sure about Windows, but I know that xorgxrdp does not supply a useful AND mask when it transmits a cursor with an Alpha channel - in fact it leaves the AND-mask as all zeros, which makes rdesktop display the cursor in a black box.  I do not know what the spec requires (or if there even is a spec) but other RDP clients are ignoring the useless AND mask and using the Alpha channel instead.  Here is one possible way of doing this: it treats the AND mask as opaque if and only if the opacity value is above some threshold (I've chosen 0xf0 which seems to work with xorgxrdp but this is somewhat arbitrary).  Ultimately it would be good to get rdesktop to support colour cursors as FreeRDP does, but I don't think I have development time for that.