### PR TITLE
Silence "sec_process_crypt_info(), failed to parse crypt info" msgs

### DIFF
--- a/secure.c
+++ b/secure.c
@@ -557,6 +557,7 @@ sec_parse_crypt_info(STREAM s, uint32 * rc4_key_size,
 	if (crypt_level == 0)
 	{
 		/* no encryption */
+		logger(Protocol, Debug, "sec_parse_crypt_info(), got ENCRYPTION_LEVEL_NONE");
 		return False;
 	}
 
@@ -575,7 +576,10 @@ sec_parse_crypt_info(STREAM s, uint32 * rc4_key_size,
 	/* RSA info */
 	end = s->p + rsa_info_len;
 	if (end > s->end)
+	{
+		logger(Protocol, Error, "sec_parse_crypt_info(), end > s->end");
 		return False;
+	}
 
 	in_uint32_le(s, flags);	/* 1 = RDP4-style, 0x80000002 = X.509 */
 	if (flags & 1)
@@ -595,7 +599,11 @@ sec_parse_crypt_info(STREAM s, uint32 * rc4_key_size,
 			{
 				case SEC_TAG_PUBKEY:
 					if (!sec_parse_public_key(s, modulus, exponent))
+					{
+						logger(Protocol, Error,
+						       "sec_parse_crypt_info(), invalid public key");
 						return False;
+					}
 					logger(Protocol, Debug,
 					       "sec_parse_crypt_info(), got public key");
 
@@ -603,7 +611,11 @@ sec_parse_crypt_info(STREAM s, uint32 * rc4_key_size,
 
 				case SEC_TAG_KEYSIG:
 					if (!sec_parse_public_sig(s, length, modulus, exponent))
+					{
+						logger(Protocol, Error,
+						       "sec_parse_crypt_info(), invalid public sig");
 						return False;
+					}
 					break;
 
 				default:
@@ -727,10 +739,7 @@ sec_process_crypt_info(STREAM s)
 	memset(modulus, 0, sizeof(modulus));
 	memset(exponent, 0, sizeof(exponent));
 	if (!sec_parse_crypt_info(s, &rc4_key_size, &server_random, modulus, exponent))
-	{
-		logger(Protocol, Error, "sec_process_crypt_info(), failed to parse crypt info");
 		return;
-	}
 
 	logger(Protocol, Debug, "sec_parse_crypt_info(), generating client random");
 	generate_random(g_client_random);


### PR DESCRIPTION
If sec_parse_crypt_info returns false, it's not always a problem with
parsing the crypt info. It could very well be that Enhanced RDP
Security is used, which would trigger a false return value from the
function.

This commit adds new log messages to sec_parse_crypt_info for cases it
would return false and removes the incorrect catch-all message from
the caller.