### PR TITLE
rdpsnd_process_ping: include actual packsize value in reply

### DIFF
--- a/rdpsnd.c
+++ b/rdpsnd.c
@@ -5,6 +5,7 @@
    Copyright 2009-2011 Peter Astrand <astrand@cendio.se> for Cendio AB
    Copyright (C) Matthew Chapman <matthewc.unsw.edu.au> 2003-2008
    Copyright (C) GuoJunBo <guojunbo@ict.ac.cn> 2003
+   Copyright 2017 Karl Mikaelsson <derfian@cendio.se> for Cendio AB
 
    This program is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -258,15 +259,17 @@ static void
 rdpsnd_process_ping(STREAM in)
 {
 	uint16 tick;
+	uint16 packsize;
 	STREAM out;
 
 	in_uint16_le(in, tick);
+	in_uint16_le(in, packsize);
 
 	logger(Sound, Debug, "rdpsmd_process_ping(), tick = 0x%04x", (unsigned) tick);
 
 	out = rdpsnd_init_packet(RDPSND_PING | 0x2300, 4);
 	out_uint16_le(out, tick);
-	out_uint16_le(out, 0);
+	out_uint16_le(out, packsize);
 	s_mark_end(out);
 	rdpsnd_send(out);
 }


### PR DESCRIPTION
The rdpsnd_process_ping function did not conform to the MS-RDPEA spec by leaving out the packsize in the reply. The MS-RDPEA spec is rather clear that this needs to be the same value as received in the training request.

I think I'm seeing a slight improvement in audio sync after this change but I'd love to have more people test this and see if it makes a difference.