### PR TITLE
Fix osx build

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -123,9 +123,19 @@ fi
 dnl CredSSP feature
 AC_ARG_ENABLE([credssp], AS_HELP_STRING([--disable-credssp], [disable support for CredSSP]))
 AS_IF([test "x$enable_credssp" != "xno"], [
-	  if test -n "$PKG_CONFIG"; then
-	    PKG_CHECK_MODULES(GSSAPI, krb5-gssapi, [WITH_CREDSSP=1], [WITH_CREDSSP=0])
-	  fi
+	case "$OSTYPE" in
+	     darwin*)
+		AC_CHECK_HEADER(Kerberos/gssapi_krb5.h, [WITH_CREDSSP=1], [WITH_CREDSSP=0])
+		GSSAPI_CFLAGS=""
+		GSSAPI_LIBS="-framework Kerberos"
+		;;
+	     *)
+		if test -n "$PKG_CONFIG"; then
+		  PKG_CHECK_MODULES(GSSAPI, krb5-gssapi, [WITH_CREDSSP=1], [WITH_CREDSSP=0])
+		fi
+		;;
+	esac
+
 
 	  if test x"$WITH_CREDSSP" = "x1"; then
 	      CREDSSPOBJ="cssp.o"

--- a/scard.c
+++ b/scard.c
@@ -33,6 +33,7 @@
 #include <PCSC/wintypes.h>
 #include <PCSC/pcsclite.h>
 #include <PCSC/winscard.h>
+#define SCARD_CTL_CODE(code) (0x42000000 + (code))
 #else
 #include <wintypes.h>
 #include <pcsclite.h>

--- a/xwin.c
+++ b/xwin.c
@@ -37,6 +37,11 @@
 #include <X11/extensions/Xrandr.h>
 #endif
 
+#ifdef __APPLE__
+#include <sys/param.h>
+#define HOST_NAME_MAX MAXHOSTNAMELEN
+#endif
+
 extern int g_sizeopt;
 extern int g_width;
 extern int g_height;


### PR DESCRIPTION
Fix building rdesktop on macOS X:
- Use Kerberos framework for CredSSP
- No SCARD_CTL_CODE(code) in Apple's PC/SC
- No HOST_NAME_MAX on OS X

To verify:
1) Install Homebrew
2) brew install autoconf automake pkg-config openssl
3) Install XQuartz (X11)
4) build with either Apple supplied PC/SC or libpcsclite (install pcsclit using brew and set PCSCLITE_LIBS and PCSCLITE_CFLAGS to point to install location)

````bash
$ ./bootstrap
$ PKG_CONFIG_PATH=/opt/X11/lib/pkgconfig ./configure --with-openssl=/usr/local/opt/openssl 
$ make

I built and verified that I can connect to Windows 7 box with either one or two smartcard readers.