### PR TITLE
Add osx support for Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,27 @@
-dist: trusty
+matrix:
+  include:
+    - os: linux
+      dist: trusty
+      sudo: required
+      compiler: gcc
+    - os: osx
+      osx_image: xcode7.3
+      compiler: clang
 
 language: c
 
-compiler: gcc
 
 notifications:
     slack: rdesktop:RZWCtYeVc9qVzsBvTzQtmyLt
     
 before_install:
- - sudo apt-get -qq update
- - sudo apt-get install -y libpcsclite-dev libxcursor-dev libao-dev libasound2-dev
+ - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update ; fi
+ - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install openssl ; fi
+ - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get -qq update ; fi
+ - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -y libpcsclite-dev libxcursor-dev libao-dev libasound2-dev ; fi
 
-script: ./bootstrap && ./configure && make
+script: 
+    - ./bootstrap
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then PKG_CONFIG_PATH=/opt/X11/lib/pkgconfig ./configure --with-openssl=/usr/local/opt/openssl ; fi
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./configure ; fi
+    - make


### PR DESCRIPTION
Fixes #163
Notes:
- No need to install autoconf, automake and pkg-config as they are already there for OSX Travis CI image (See https://docs.travis-ci.com/user/reference/osx/)
- Additional info for using Travis for testing build on multiple OSes:
https://docs.travis-ci.com/user/multi-os/
