### PR TITLE
Remove global variable g_bitmap_compression

### DIFF
--- a/rdesktop.c
+++ b/rdesktop.c
@@ -83,7 +83,6 @@ extern int g_tcp_port_rdp;
 int g_server_depth = -1;
 int g_win_button_size = 0;	/* If zero, disable single app mode */
 RD_BOOL g_network_error = False;
-RD_BOOL g_bitmap_compression = True;
 RD_BOOL g_sendmotion = True;
 RD_BOOL g_bitmap_cache = True;
 RD_BOOL g_bitmap_cache_persist_enable = False;

--- a/rdp.c
+++ b/rdp.c
@@ -35,7 +35,6 @@ extern uint16 g_mcs_userid;
 extern char *g_username;
 extern char g_password[64];
 extern char g_codepage[16];
-extern RD_BOOL g_bitmap_compression;
 extern RD_BOOL g_orders;
 extern RD_BOOL g_encryption;
 extern RD_BOOL g_desktop_save;

--- a/uiports/nanoxwin.c
+++ b/uiports/nanoxwin.c
@@ -45,7 +45,6 @@ int g_polygon_ellipse_orders = 0;
 int g_bitmap_cache = 1;
 int g_bitmap_cache_persist_enable = 0;
 int g_bitmap_cache_precache = 1;
-int g_bitmap_compression = 1;
 uint32 g_rdp5_performanceflags =
   RDP5_NO_WALLPAPER | RDP5_NO_FULLWINDOWDRAG | RDP5_NO_MENUANIMATIONS;
 int g_console_session = 0;

--- a/uiports/qtewin.cpp
+++ b/uiports/qtewin.cpp
@@ -57,7 +57,6 @@ int g_bitmap_cache_persist_enable = 0;
 int g_bitmap_cache_precache = 1;
 int g_use_rdp5 = 1;
 int g_desktop_save = 1;
-int g_bitmap_compression = 1;
 int g_polygon_ellipse_orders = 0;
 int g_rdp5_performanceflags =
   RDP5_NO_WALLPAPER | RDP5_NO_FULLWINDOWDRAG | RDP5_NO_MENUANIMATIONS;

--- a/uiports/qtwin.cpp
+++ b/uiports/qtwin.cpp
@@ -55,7 +55,6 @@ int g_polygon_ellipse_orders = 0;
 int g_bitmap_cache = 1;
 int g_bitmap_cache_persist_enable = False;
 int g_bitmap_cache_precache = True;
-int g_bitmap_compression = 1;
 int g_rdp5_performanceflags = 0;
 int g_console_session = 0;
 int g_keylayout = 0x409; /* Defaults to US keyboard layout */

--- a/uiports/svgawin.c
+++ b/uiports/svgawin.c
@@ -46,7 +46,6 @@ int g_polygon_ellipse_orders = 0;
 int g_bitmap_cache = 1;
 int g_bitmap_cache_persist_enable = False;
 int g_bitmap_cache_precache = True;
-int g_bitmap_compression = 1;
 int g_rdp5_performanceflags = 0;
 int g_console_session = 0;
 int g_keylayout = 0x409; /* Defaults to US keyboard layout */

--- a/uiports/xxxwin.c
+++ b/uiports/xxxwin.c
@@ -32,7 +32,6 @@ RD_BOOL g_polygon_ellipse_orders = False;
 RD_BOOL g_bitmap_cache = True;
 RD_BOOL g_bitmap_cache_persist_enable = False;
 RD_BOOL g_bitmap_cache_precache = True;
-RD_BOOL g_bitmap_compression = True;
 uint32 g_rdp5_performanceflags = 0;
 RD_BOOL g_console_session = False;
 uint32 g_keylayout = 0x409; /* Defaults to US keyboard layout */


### PR DESCRIPTION
g_bitmap_compression is a global variable scattered through the code
but only accessed and used in one place; rdp_out_bitmap_caps().
Demoted it to localvariable and replaced with hardcoded value.