### PR TITLE
Rename .cvsignore to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
 rdesktop
-rdp2vnc
 autom4te.cache
 Makefile
 config.log
 config.status
 configure
 rdesktop*.tar.gz
+aclocal.m4


### PR DESCRIPTION
CVS is thankfully a thing of the past by now, but we can reuse the .cvsignore file as a .gitignore file.