### PR TITLE
Added bootstrap to build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ and 5 protocols.
 rdesktop uses a GNU-style build procedure.  Typically all that is necessary
 to install rdesktop is the following:
 
+	% ./bootstrap
 	% ./configure
 	% make
 	% make install


### PR DESCRIPTION
It is not mentioned within the README that one needs to run the script bootstrap / autoconf before running `./configure`. This adds one line to README and decreases level of entry for compiling the source. 