### PR TITLE
Clean up undefined behavior in complicated and/or/shift expression

### DIFF
--- a/mppc.c
+++ b/mppc.c
@@ -349,9 +349,9 @@ mppc_expand(uint8 * data, uint32 clen, uint8 ctype, uint32 * roff, uint32 * rlen
 			}
 
 			match_bits = match_len;
-			match_len =
-				((walker >> (32 - match_bits)) & (~(-1 << match_bits))) | (1 <<
-											   match_bits);
+			match_len = (walker >> (32 - match_bits));
+			match_len &= ((1 << match_bits) - 1);
+			match_len |= (1 << match_bits);
 			walker <<= match_bits;
 			walker_len -= match_bits;
 		}


### PR DESCRIPTION
Shifting negative values is technically undefined, and we can describe
what we want to do in ways that are easier to read.