### PR TITLE
Ignore object files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ config.status
 configure
 rdesktop*.tar.gz
 aclocal.m4
+*.o


### PR DESCRIPTION
After building rdesktop on my computer git status showed a lot of ".o" files as untracked files.

Since ".o" files are not supposed to be added I think it's a good idea to hide them.