### PR TITLE
Fix file sizes for redirected disks

### DIFF
--- a/stream.h
+++ b/stream.h
@@ -64,7 +64,6 @@ size_t in_ansi_string(STREAM s, char *string, size_t len);
 #define in_uint32_le(s,v)	{ v = *(uint32 *)((s)->p); (s)->p += 4; }
 #define out_uint16_le(s,v)	{ *(uint16 *)((s)->p) = v; (s)->p += 2; }
 #define out_uint32_le(s,v)	{ *(uint32 *)((s)->p) = v; (s)->p += 4; }
-
 #else
 #define in_uint16_le(s,v)	{ v = *((s)->p++); v += *((s)->p++) << 8; }
 #define in_uint32_le(s,v)	{ in_uint16_le(s,v) \
@@ -72,6 +71,8 @@ size_t in_ansi_string(STREAM s, char *string, size_t len);
 #define out_uint16_le(s,v)	{ *((s)->p++) = (v) & 0xff; *((s)->p++) = ((v) >> 8) & 0xff; }
 #define out_uint32_le(s,v)	{ out_uint16_le(s, (v) & 0xffff); out_uint16_le(s, ((v) >> 16) & 0xffff); }
 #endif
+
+#define out_uint64_le(s,v)	{ out_uint32_le(s, (v) & 0xffffffff); out_uint32_le(s, ((v) >> 32) & 0xffffffff); }
 
 #if defined(B_ENDIAN) && !defined(NEED_ALIGN)
 #define in_uint16_be(s,v)	{ v = *(uint16 *)((s)->p); (s)->p += 2; }


### PR DESCRIPTION
Provide the full size for files during disk redirection.

We are not supplying full size info.
Check with file sizes bigger than 32 bits.

This affects not only display sizes in Explorer, but copy (and which is more severe appending data to the file too) operations are affected as well.