### PR TITLE
Rename functions that send Client Info PDU and handle Set Error Info PDU

### DIFF
--- a/proto.h
+++ b/proto.h
@@ -158,7 +158,6 @@ void process_system_pointer_pdu(STREAM s);
 void set_system_pointer(uint32 ptr);
 void process_bitmap_updates(STREAM s);
 void process_palette(STREAM s);
-void process_disconnect_pdu(STREAM s, uint32 * ext_disc_reason);
 void rdp_main_loop(RD_BOOL * deactivated, uint32 * ext_disc_reason);
 RD_BOOL rdp_loop(RD_BOOL * deactivated, uint32 * ext_disc_reason);
 RD_BOOL rdp_connect(char *server, uint32 flags, char *domain, char *password, char *command,

--- a/rdp.c
+++ b/rdp.c
@@ -308,10 +308,10 @@ rdp_in_unistr(STREAM s, int in_len, char **string, uint32 * str_size)
 }
 
 
-/* Parse a logon info packet */
+/* Send a Client Info PDU */
 static void
-rdp_send_logon_info(uint32 flags, char *domain, char *user,
-		    char *password, char *program, char *directory)
+rdp_send_client_info_pdu(uint32 flags, char *domain, char *user,
+			 char *password, char *program, char *directory)
 {
 	char *ipaddr = tcp_get_address();
 	/* length of string in TS_INFO_PACKET excludes null terminator */
@@ -1878,7 +1878,7 @@ rdp_connect(char *server, uint32 flags, char *domain, char *password,
 	if (!sec_connect(server, g_username, domain, password, reconnect))
 		return False;
 
-	rdp_send_logon_info(flags, domain, g_username, password, command, directory);
+	rdp_send_client_info_pdu(flags, domain, g_username, password, command, directory);
 
 	/* run RDP loop until first licence demand active PDU */
 	while (!g_rdp_shareid)

--- a/rdp.c
+++ b/rdp.c
@@ -1512,13 +1512,13 @@ process_pdu_logon(STREAM s)
 }
 
 
-/* Process a disconnect PDU */
-void
-process_disconnect_pdu(STREAM s, uint32 * ext_disc_reason)
+/* Process a Set Error Info PDU */
+static void
+process_ts_set_error_info_pdu(STREAM s, uint32 * ext_disc_reason)
 {
 	in_uint32_le(s, *ext_disc_reason);
 
-	logger(Protocol, Debug, "process_disconnect_pdu(), reason = %d", ext_disc_reason);
+	logger(Protocol, Debug, "process_ts_set_error_info_pdu(), error info = %d", *ext_disc_reason);
 }
 
 /* Process data PDU */
@@ -1594,7 +1594,7 @@ process_data_pdu(STREAM s, uint32 * ext_disc_reason)
 			break;
 
 		case RDP_DATA_PDU_DISCONNECT:
-			process_disconnect_pdu(s, ext_disc_reason);
+			process_ts_set_error_info_pdu(s, ext_disc_reason);
 
 			/* We used to return true and disconnect immediately here, but
 			 * Windows Vista sends a disconnect PDU with reason 0 when


### PR DESCRIPTION
Being able to cross-reference our code with MS-RDPBCGR is a good thing. This PR renames the functions that handle the Client Info PDU and the Set Error Info PDU to fit with MS-RDPBCGR.

This PR also marks process_ts_set_error_info_pdu as static and removes it from proto.h. Nothing outside of rdp.c calls it.