### PR TITLE
Clear g_exit_mainloop before new connection

### DIFF
--- a/rdp.c
+++ b/rdp.c
@@ -1810,9 +1810,6 @@ rdp_main_loop(RD_BOOL * deactivated, uint32 * ext_disc_reason)
 			g_exit_mainloop = True;
 		}
 	} while(g_exit_mainloop == False);
-
-	/* clear the exit main loop flag */
-	g_exit_mainloop = False;
 }
 
 /* used in uiports and rdp_main_loop, processes the RDP packets waiting */
@@ -1901,6 +1898,7 @@ rdp_reset_state(void)
 {
 	g_next_packet = NULL;	/* reset the packet information */
 	g_rdp_shareid = 0;
+	g_exit_mainloop = False;
 	sec_reset_state();
 }
 


### PR DESCRIPTION
Reuse of g_exit_mainloop can occur at various situations
such as on redirection, when a new connection is initialized.

If you call rdp_loop with this flag set, things will not work as
you'd expect.

Fixes issue #228

Signed-off-by: Henrik Andersson <hean01@cendio.com>
Signed-off-by: Karl Mikaelsson <derfian@cendio.se>