### PR TITLE
Fix to compile with gcc 7.3.0 and possibly fix a security issue

### DIFF
--- a/rdesktop.c
+++ b/rdesktop.c
@@ -517,7 +517,7 @@ read_password(char *password, int size)
 
 	if (tcgetattr(STDIN_FILENO, &tios) == 0)
 	{
-		fprintf(stderr, prompt);
+		fputs(prompt, stderr);
 		tios.c_lflag &= ~ECHO;
 		tcsetattr(STDIN_FILENO, TCSANOW, &tios);
 		istty = 1;


### PR DESCRIPTION
Did a google search and found this.
https://stackoverflow.com/questions/4419293/warning-format-not-a-string-literal-and-no-format-arguments/4419319#4419319

With this little fix, rdesktop compiled again using gcc 7.3.0.