### PR TITLE
Remove implicit fall-throughs from bitmap.c and parallel.c

### DIFF
--- a/bitmap.c
+++ b/bitmap.c
@@ -135,6 +135,8 @@ bitmap_decompress1(uint8 * output, int width, int height, uint8 * input, int siz
 				break;
 			case 8:	/* Bicolour */
 				colour1 = CVAL(input);
+				colour2 = CVAL(input);
+				break;
 			case 3:	/* Colour */
 				colour2 = CVAL(input);
 				break;
@@ -333,6 +335,8 @@ bitmap_decompress2(uint8 * output, int width, int height, uint8 * input, int siz
 				break;
 			case 8:	/* Bicolour */
 				CVAL2(input, colour1);
+				CVAL2(input, colour2);
+				break;
 			case 3:	/* Colour */
 				CVAL2(input, colour2);
 				break;
@@ -535,6 +539,10 @@ bitmap_decompress3(uint8 * output, int width, int height, uint8 * input, int siz
 				colour1[0] = CVAL(input);
 				colour1[1] = CVAL(input);
 				colour1[2] = CVAL(input);
+				colour2[0] = CVAL(input);
+				colour2[1] = CVAL(input);
+				colour2[2] = CVAL(input);
+				break;
 			case 3:	/* Colour */
 				colour2[0] = CVAL(input);
 				colour2[1] = CVAL(input);

--- a/parallel.c
+++ b/parallel.c
@@ -144,12 +144,16 @@ parallel_write(RD_NTHANDLE handle, uint8 * data, uint32 length, uint32 offset, u
 		{
 			case EAGAIN:
 				rc = RD_STATUS_DEVICE_OFF_LINE;
+				break;
 			case ENOSPC:
 				rc = RD_STATUS_DEVICE_PAPER_EMPTY;
+				break;
 			case EIO:
 				rc = RD_STATUS_DEVICE_OFF_LINE;
+				break;
 			default:
 				rc = RD_STATUS_DEVICE_POWERED_OFF;
+				break;
 		}
 #if defined(LPGETSTATUS)
 		if (ioctl(handle, LPGETSTATUS, &status) == 0)


### PR DESCRIPTION
This removes compilation warnings from recent GCC versions by reworking the code to remove fall-through statements. It's a different way of solving the underlying problem that PR #242 tried to address.