### PR TITLE
Introduce a type for the Fast-Path header

### DIFF
--- a/iso.c
+++ b/iso.c
@@ -98,7 +98,7 @@ iso_send_connection_request(char *username, uint32 neg_proto)
 
 /* Receive a message on the ISO layer, return code */
 static STREAM
-iso_recv_msg(uint8 * code, RD_BOOL *is_fastpath, uint8 *fastpath_hdr)
+iso_recv_msg(uint8 * code, RD_BOOL *is_fastpath, fastpath_hdr_t *fastpath_hdr)
 {
 	STREAM s;
 	uint16 length;
@@ -111,7 +111,7 @@ iso_recv_msg(uint8 * code, RD_BOOL *is_fastpath, uint8 *fastpath_hdr)
 	in_uint8(s, version); /* T.123 version or Fastpath output header */
 
 	/* detect if this is a slow or fast path PDU */
-	*fastpath_hdr = 0x00;
+	fastpath_hdr->raw = 0x00;
 	*is_fastpath = False;
 	if (version == T123_HEADER_VERSION)
 	{
@@ -123,7 +123,7 @@ iso_recv_msg(uint8 * code, RD_BOOL *is_fastpath, uint8 *fastpath_hdr)
 		/* if version is not an expected T.123 version eg. 3, then this
 		   stream is a fast path pdu */
 		*is_fastpath = True;
-		*fastpath_hdr = version;
+		fastpath_hdr->raw = version;
 		in_uint8(s, length); /* length1 */
 		if (length & 0x80)
 		{
@@ -191,7 +191,7 @@ iso_send(STREAM s)
 
 /* Receive ISO transport data packet */
 STREAM
-iso_recv(RD_BOOL *is_fastpath, uint8 *fastpath_hdr)
+iso_recv(RD_BOOL *is_fastpath, fastpath_hdr_t *fastpath_hdr)
 {
 	STREAM s;
 	uint8 code = 0;
@@ -221,7 +221,7 @@ iso_connect(char *server, char *username, char *domain, char *password,
 	uint8 code;
 	uint32 neg_proto;
 	RD_BOOL is_fastpath;
-	uint8 fastpath_hdr;
+	fastpath_hdr_t fastpath_hdr;
 
 	g_negotiate_rdp_protocol = True;
 

--- a/mcs.c
+++ b/mcs.c
@@ -92,7 +92,7 @@ mcs_recv_connect_response(STREAM mcs_data)
 	int length;
 	STREAM s;
 	RD_BOOL is_fastpath;
-	uint8 fastpath_hdr;
+	fastpath_hdr_t fastpath_hdr;
 
 	logger(Protocol, Debug, "%s()", __func__);
 	s = iso_recv(&is_fastpath, &fastpath_hdr);
@@ -166,7 +166,7 @@ static RD_BOOL
 mcs_recv_aucf(uint16 * mcs_userid)
 {
 	RD_BOOL is_fastpath;
-	uint8 fastpath_hdr;
+	fastpath_hdr_t fastpath_hdr;
 	uint8 opcode, result;
 	STREAM s;
 
@@ -219,7 +219,7 @@ static RD_BOOL
 mcs_recv_cjcf(void)
 {
 	RD_BOOL is_fastpath;
-	uint8 fastpath_hdr;
+	fastpath_hdr_t fastpath_hdr;
 	uint8 opcode, result;
 	STREAM s;
 
@@ -316,7 +316,7 @@ mcs_send(STREAM s)
 
 /* Receive an MCS transport data packet */
 STREAM
-mcs_recv(uint16 * channel, RD_BOOL *is_fastpath, uint8 *fastpath_hdr)
+mcs_recv(uint16 * channel, RD_BOOL *is_fastpath, fastpath_hdr_t *fastpath_hdr)
 {
 	uint8 opcode, appid, length;
 	STREAM s;

--- a/proto.h
+++ b/proto.h
@@ -82,7 +82,7 @@ void ewmh_init(void);
 /* iso.c */
 STREAM iso_init(int length);
 void iso_send(STREAM s);
-STREAM iso_recv(RD_BOOL *is_fastpath, uint8 *fastpath_hdr);
+STREAM iso_recv(RD_BOOL *is_fastpath, fastpath_hdr_t *fastpath_hdr);
 RD_BOOL iso_connect(char *server, char *username, char *domain, char *password, RD_BOOL reconnect,
 		    uint32 * selected_protocol);
 void iso_disconnect(void);
@@ -95,7 +95,7 @@ void licence_process(STREAM s);
 STREAM mcs_init(int length);
 void mcs_send_to_channel(STREAM s, uint16 channel);
 void mcs_send(STREAM s);
-STREAM mcs_recv(uint16 * channel, RD_BOOL *is_fastpath, uint8 *fastpath_hdr);
+STREAM mcs_recv(uint16 * channel, RD_BOOL *is_fastpath, fastpath_hdr_t *fastpath_hdr);
 RD_BOOL mcs_connect_start(char *server, char *username, char *domain, char *password,
 			  RD_BOOL reconnect, uint32 * selected_protocol);
 RD_BOOL mcs_connect_finalize(STREAM s);

--- a/secure.c
+++ b/secure.c
@@ -844,7 +844,7 @@ sec_process_mcs_data(STREAM s)
 STREAM
 sec_recv(RD_BOOL *is_fastpath)
 {
-	uint8 fastpath_hdr, fastpath_flags;
+	fastpath_hdr_t fastpath_hdr;
 	uint16 sec_flags;
 	uint16 channel;
 	STREAM s;
@@ -855,9 +855,7 @@ sec_recv(RD_BOOL *is_fastpath)
 		{
 			/* If fastpath packet is encrypted, read data
 			   signature and decrypt */
-			/* FIXME: extracting flags from hdr could be made less obscure */
-			fastpath_flags = (fastpath_hdr & 0xC0) >> 6;
-			if (fastpath_flags & FASTPATH_OUTPUT_ENCRYPTED)
+			if (fastpath_hdr.fields.flags & FASTPATH_OUTPUT_ENCRYPTED)
 			{
 				in_uint8s(s, 8);	/* signature */
 				sec_decrypt(s->p, s->end - s->p);

--- a/types.h
+++ b/types.h
@@ -315,4 +315,13 @@ typedef enum {
 	Fullscreen,
 } window_size_type_t;
 
+typedef union fastpath_hdr_t {
+    uint8 raw;
+    struct {
+	uint8 action:2;
+	uint8 reserved:4;
+	uint8 flags:2;
+    } fields;
+} fastpath_hdr_t;
+
 #endif /* _TYPES_H */


### PR DESCRIPTION
Allow access to Fast-Path header fields through a dedicated type. This reduces the amount of binary arithmetic with semi-magic constants scattered around the codebase.

This is a follow-up to 08c293b, in which I introduced a FIXME.