### PR TITLE
(README): add instructions to install autoconf

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ and 5 protocols.
 rdesktop uses a GNU-style build procedure.  Typically all that is necessary
 to install rdesktop is the following:
 
+	% sudo apt install autoconf
 	% ./configure
 	% make
 	% make install


### PR DESCRIPTION
I got an error `./bootstrap: 3: ./bootstrap: autoreconf: not found` when trying to install.

If you prefer not to add this line to the "default" installing steps, maybe add it below?

something like "if you run into `autoreconf: not found` error, follow this step", or something similar