### PR TITLE
Instruct users to run ./bootstrap before ./configure

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ and 5 protocols.
 rdesktop uses a GNU-style build procedure.  Typically all that is necessary
 to install rdesktop is the following:
 
+	% ./bootstrap
 	% ./configure
 	% make
 	% make install


### PR DESCRIPTION
After cloning the repository, there is no `./configure` file. It seems that `./bootstrap` is the command that is supposed to generate the configure file which then generates the makefile.

Strangely, the [bootstrap file was last changed](https://github.com/rdesktop/rdesktop/commits/master/bootstrap) in 2004, and the configure file was deleted in [that same commit](https://github.com/rdesktop/rdesktop/commit/336cb6cc1f0ee0568e3431e90d6aaf5ae8af6b1f#diff-e2d5a00791bce9a01f99bc6fd613a39d). I am curious if I'm doing this wrong, or if nobody noticed the outdated instructions in 14 years.