### PR TITLE
Bind Shift-Ctrl-Alt-Enter to iconify rdesktop.

### DIFF
--- a/doc/keymapping.txt
+++ b/doc/keymapping.txt
@@ -198,7 +198,9 @@ Special keys
 ============
 
 * The combination Ctrl-Alt-Enter toggles between fullscreen and
-  non-fullscreen mode. 
+  non-fullscreen mode.
+
+* The combination Shift-Ctrl-Alt-Enter iconifies rdesktop.
 
 * Meta, Hyper and Super are treated as windows keys. RDP4 does not
   support the windows keys though, so if you are running RDP4, these

--- a/doc/rdesktop.1
+++ b/doc/rdesktop.1
@@ -90,7 +90,8 @@ This feature also requires that smart card redirection is used using \f-r scard\
 .BR "-f"
 Enable fullscreen mode.  This overrides the window manager and causes the
 rdesktop window to fully cover the current screen.  Fullscreen mode can be
-toggled at any time using Ctrl-Alt-Enter.
+toggled at any time using Ctrl-Alt-Enter.  Shift-Ctrl-Alt-Enter will iconify
+the application.
 .TP
 .BR "-b"
 Force the server to send screen updates as bitmaps rather than using

--- a/proto.h
+++ b/proto.h
@@ -267,6 +267,7 @@ void ui_destroy_window(void);
 void ui_update_window_sizehints(uint32 width, uint32 height);
 RD_BOOL ui_have_window(void);
 void xwin_toggle_fullscreen(void);
+void xwin_toggle_iconified(void);
 void ui_select(int rdp_socket);
 void ui_move_pointer(int x, int y);
 RD_HBITMAP ui_create_bitmap(int width, int height, uint8 * data);

--- a/xkeymap.c
+++ b/xkeymap.c
@@ -48,6 +48,7 @@ extern RD_BOOL g_seamless_rdp;
 extern RD_BOOL g_seamless_active;
 extern RDP_VERSION g_rdp_version;
 extern RD_BOOL g_numlock_sync;
+extern RD_BOOL g_fullscreen;
 
 static RD_BOOL keymap_loaded;
 static key_translation_entry *keymap[KEYMAP_SIZE];
@@ -647,7 +648,14 @@ handle_special_keys(uint32 keysym, unsigned int state, uint32 ev_time, RD_BOOL p
 				/* Ctrl-Alt-Enter: toggle full screen */
 				if (pressed)
 				{
-					if (!g_seamless_rdp)
+					if (get_key_state(state, XK_Shift_L) || get_key_state(state, XK_Shift_R))
+					{
+						/* Can only iconify if not fullscreen */
+						if (g_fullscreen)
+							xwin_toggle_fullscreen();
+						xwin_toggle_iconified();
+					}						
+					else if (!g_seamless_rdp)
 					{
 						/* only allow toggle fullscreen when not running
 						   rdesktop in seamless mode */

--- a/xwin.c
+++ b/xwin.c
@@ -2418,6 +2418,16 @@ xwin_toggle_fullscreen(void)
 	}
 }
 
+void
+xwin_toggle_iconified(void)
+{
+	/* When running rdesktop in seamless mode, toggling of iconified state is not allowed */
+	if (!g_seamless_active)
+	{
+		XIconifyWindow(g_display, g_wnd, XScreenNumberOfScreen(g_screen));
+	}
+}
+
 static void
 handle_button_event(XEvent xevent, RD_BOOL down)
 {


### PR DESCRIPTION
Implementation for https://github.com/rdesktop/rdesktop/issues/291