### PR TITLE
Fix FreeBSD build

### DIFF
--- a/xwin.c
+++ b/xwin.c
@@ -47,6 +47,10 @@
 #define HOST_NAME_MAX MAXHOSTNAMELEN
 #endif
 
+#ifdef __FreeBSD__
+#define HOST_NAME_MAX _POSIX_HOST_NAME_MAX
+#endif
+
 extern RD_BOOL g_user_quit;
 extern RD_BOOL g_exit_mainloop;
 


### PR DESCRIPTION
HOST_NAME_MAX is not defined on FreeBSD.