### PR TITLE
Fix memory leaks

### DIFF
--- a/secure.c
+++ b/secure.c
@@ -683,6 +683,10 @@ sec_parse_crypt_info(STREAM s, uint32 * rc4_key_size,
 				logger(Protocol, Error,
 				       "sec_parse_crypt_info(), got a bad cert: this will probably screw up the rest of the communication");
 			}
+			else
+			{
+				rdssl_cert_free(ignorecert);
+			}
 		}
 		/* Do da funky X.509 stuffy
 

--- a/ssl.c
+++ b/ssl.c
@@ -156,7 +156,8 @@ rdssl_cert_read(uint8 * data, uint32 len)
 void
 rdssl_cert_free(RDSSL_CERT * cert)
 {
-	gnutls_free(cert);
+	gnutls_x509_crt_deinit(*cert);
+	free(cert);
 }
 
 

--- a/ssl.c
+++ b/ssl.c
@@ -114,6 +114,11 @@ rdssl_rsa_encrypt(uint8 * out, uint8 * in, int len, uint32 modulus_size, uint8 *
 
 	mpz_export(out, &outlen, -1, sizeof(out[0]), 0, 0, y);
 
+	mpz_clear(y);
+	mpz_clear(x);
+	mpz_clear(exp);
+	mpz_clear(mod);
+
 	if (outlen < (int) modulus_size)
 		memset(out + outlen, 0, modulus_size - outlen);
 }


### PR DESCRIPTION
Variables of type mpz_t must be cleared with mpz_clear().
Certificates initialized with gnutls_x509_crt_init() must be freed with gnutls_x509_crt_deinit().
The return values of XGetAtomName() have to be freed with XFree().