### PR TITLE
support status flags of newer GnuTLS

### DIFF
--- a/utils.c
+++ b/utils.c
@@ -847,11 +847,38 @@ _utils_cert_get_status_report(gnutls_x509_crt_t cert, unsigned int status,
 		size -= strlen(buf);
 	}
 
-#if GNUTLS_VERSION_NUMBER >= 0x030600
+#if GNUTLS_VERSION_NUMBER >= 0x030400
 	if (status & GNUTLS_CERT_PURPOSE_MISMATCH) {
 		snprintf(buf, sizeof(buf),
 			" %d. The certificate or an intermediate does not match the\n"
 			"     intended purpose (extended key usage).\n\n", i++);
+		strncat(out, buf, size);
+		size -= strlen(buf);
+	}
+#endif
+
+#if GNUTLS_VERSION_NUMBER >= 0x030501
+	if (status & GNUTLS_CERT_MISSING_OCSP_STATUS) {
+		snprintf(buf, sizeof(buf),
+			" %d. The certificate requires the server to send the certifiate\n"
+			"     status, but no status was received.\n\n", i++);
+		strncat(out, buf, size);
+		size -= strlen(buf);
+	}
+
+	if (status & GNUTLS_CERT_INVALID_OCSP_STATUS) {
+		snprintf(buf, sizeof(buf),
+			" %d. The received OCSP status response is invalid.\n\n", i++);
+		strncat(out, buf, size);
+		size -= strlen(buf);
+	}
+#endif
+
+#if GNUTLS_VERSION_NUMBER >= 0x030600
+	if (status & GNUTLS_CERT_UNKNOWN_CRIT_EXTENSIONS) {
+		snprintf(buf, sizeof(buf),
+			" %d. The certificate has extensions marked as critical which are\n"
+			"     not supported.\n\n", i++);
 		strncat(out, buf, size);
 		size -= strlen(buf);
 	}


### PR DESCRIPTION
Support status flags of newer GnuTLS in _utils_cert_get_status_report
with the appropriate GnuTLS version guards.

This code (without the version guards) was already part of the GnuTLS
branch and was removed in 9acb0cca. I think it is helpful to add it
again to get better error hints on certificate problems when using a
newer GnuTLS.