### PR TITLE
Set master version to 1.8.99 to be greater than 1.8.x versions

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT(rdesktop, 1.8.3post)
+AC_INIT(rdesktop, 1.8.99)
 
 AC_CONFIG_SRCDIR([rdesktop.c])
 

--- a/rdesktop.spec
+++ b/rdesktop.spec
@@ -1,6 +1,6 @@
 Summary: Remote Desktop Protocol client
 Name: rdesktop
-Version: 1.8.3post
+Version: 1.8.99
 Release: 1
 License: GPL; see COPYING
 Group: Applications/Communications


### PR DESCRIPTION
Fixes: https://github.com/rdesktop/rdesktop/issues/325