### PR TITLE
sec_decrypt() the correct amount of data

### DIFF
--- a/secure.c
+++ b/secure.c
@@ -813,6 +813,7 @@ sec_recv(uint8 * rdpver)
 	STREAM s;
 	struct stream packet;
 	size_t data_offset;
+	size_t remaining;
 	unsigned char *data;
 
 	while ((s = mcs_recv(&channel, rdpver)) != NULL)
@@ -832,8 +833,9 @@ sec_recv(uint8 * rdpver)
 
 					data_offset = s_tell(s);
 
-					inout_uint8p(s, data, s_remaining(s));
-					sec_decrypt(data, s_remaining(s));
+					remaining = s_remaining(s);
+					inout_uint8p(s, data, remaining);
+					sec_decrypt(data, remaining);
 
 					s_seek(s, data_offset);
 				}
@@ -860,8 +862,9 @@ sec_recv(uint8 * rdpver)
 
 					data_offset = s_tell(s);
 
-					inout_uint8p(s, data, s_remaining(s));
-					sec_decrypt(data, s_remaining(s));
+					remaining = s_remaining(s);
+					inout_uint8p(s, data, remaining);
+					sec_decrypt(data, remaining);
 				}
 
 				if (sec_flags & SEC_LICENCE_NEG)
@@ -883,8 +886,9 @@ sec_recv(uint8 * rdpver)
 
 					data_offset = s_tell(s);
 
-					inout_uint8p(s, data, s_remaining(s));
-					sec_decrypt(data, s_remaining(s));
+					remaining = s_remaining(s);
+					inout_uint8p(s, data, remaining);
+					sec_decrypt(data, remaining);
 
 					/* Check for a redirect packet, starts with 00 04 */
 					if (data[0] == 0 && data[1] == 4)


### PR DESCRIPTION
Save the correct amount of data to sec_decrypt() because after
inout_uint8p() the macro s_remaining(s) will find nothing left and
therefore calls sec_decrypt() with a length of 0.

This fixes connection problems with VirtualBox and possibly issue #333.