### PR TITLE
Windows XP: Don't expect a userid on a PDU that doesn't have one

### DIFF
--- a/rdp.c
+++ b/rdp.c
@@ -137,13 +137,17 @@ rdp_recv(uint8 * type)
 		return rdp_s;
 	}
 	in_uint16_le(rdp_s, pdu_type);
-	in_uint8s(rdp_s, 2);	/* userid */
 	*type = pdu_type & 0xf;
 
 #if WITH_DEBUG
 	DEBUG(("RDP packet #%d, (type %x)\n", ++g_packetno, *type));
 	hexdump(rdp_s->data + g_next_packet, length);
 #endif /*  */
+
+	if (*type != RDP_PDU_DEACTIVATE)
+	{
+		in_uint8s(rdp_s, 2);	/* userid */
+	}
 
 	g_next_packet += length;
 


### PR DESCRIPTION
Disclaimers:

1. Note this is against 1.8.x, since master has many other problems talking to older systems.
2. I don't know what I'm doing.
3. This doesn't appear to conform to the documentation, but does conform to the implementation.  If a user is logged onto an XP system and subsequently attempts to remote desktop into that system, the client receives a message type 6 that looks like this:
```
RDP packet #6, (type 6)
0000 04 00 16 00                                     ....
```
which doesn't conform to the TS_SHARECONTROLHEADER in that it's only four bytes, not six.

Without this, it is possible to use rdesktop 1.8.6 against XP, but not if the user has already logged on thereby implying a resolution change to an existing session.  1.8.2 works correctly.