### PR TITLE
Windows 2000: Give effect to the comment about a field that can be negative and must be treated as signed

### DIFF
--- a/orders.c
+++ b/orders.c
@@ -1250,7 +1250,7 @@ process_secondary_order(STREAM s)
 	/* The length isn't calculated correctly by the server.
 	 * For very compact orders the length becomes negative
 	 * so a signed integer must be used. */
-	uint16 length;
+	sint16 length;
 	uint16 flags;
 	uint8 type;
 	size_t next_order;
@@ -1260,12 +1260,17 @@ process_secondary_order(STREAM s)
 	in_uint16_le(s, flags);	/* used by bmpcache2 */
 	in_uint8(s, type);
 
-	if (!s_check_rem(s, length + 7))
+	length += 13;  /* MS-RDPEGDI is ridiculous and says that you need to add 13 to this
+			  field to get the total packet length. "For historical reasons". */
+	length -= 6;   /* Subtract six bytes of headers and you'll get the size of the remaining
+			  order data. */
+
+	if (!s_check_rem(s, length))
 	{
 		rdp_protocol_error("next order pointer would overrun stream", &packet);
 	}
 
-	next_order = s_tell(s) + length + 7;
+	next_order = s_tell(s) + length;
 
 	switch (type)
 	{


### PR DESCRIPTION
Disclaimers:

1. Note this is against 1.8.x, since master has many other problems talking to older systems.
2. I don't know what I'm doing.

There's a comment at the top of process_secondary_order that indicates that the length field must be treated as signed.  (Yeah, I know.)  See also PR #190 where another developer looked this up in the specification.  The security changes (understandably) didn't preserve this behavior, which causes problems when talking to Windows 2000 servers.