### PR TITLE
fix for freerdp communication

### DIFF
--- a/iso.c
+++ b/iso.c
@@ -386,6 +386,7 @@ iso_connect(char *server, char *username, char *domain, char *password,
 		else if (data == PROTOCOL_RDP)
 		{
 			logger(Core, Notice, "Connection established using plain RDP.");
+			g_encryption = False;
 		}
 		else if (data != PROTOCOL_RDP)
 		{

--- a/mcs.c
+++ b/mcs.c
@@ -156,8 +156,12 @@ mcs_send_edrq(void)
 	s = iso_init(5);
 
 	out_uint8(s, (MCS_EDRQ << 2));
-	out_uint16_be(s, 1);	/* height */
-	out_uint16_be(s, 1);	/* interval */
+	/* seq int: height */
+	out_uint8(s, 1);
+	out_uint8(s, 0);
+	/* seq int: interval */
+	out_uint8(s, 1);
+	out_uint8(s, 0);
 
 	s_mark_end(s);
 	iso_send(s);


### PR DESCRIPTION
fix for mcs_recv_erect_domain_request, from ITU-T T125:
```
ErectDomainRequest  ::=  [APPLICATION 1] IMPLICIT SEQUENCE 
{ 
 subHeight    INTEGER (0..MAX), 
      --  height in domain of the MCSPDU transmitter 
 subInterval    INTEGER (0..MAX) 
      --  its throughput enforcement interval in milliseconds 
}
```
