### PR TITLE
escape dashes in man page options

### DIFF
--- a/doc/rdesktop.1
+++ b/doc/rdesktop.1
@@ -13,40 +13,40 @@ server to Windows Server 2012 R2.
 
 .SH OPTIONS
 .TP
-.BR "-u <username>"
+.BR "\-u <username>"
 Username for authentication on the server.
 .TP
-.BR "-d <domain>"
+.BR "\-d <domain>"
 Domain for authentication.
 .TP
-.BR "-s <shell>"
+.BR "\-s <shell>"
 Startup shell for the user - starts a specific application instead of Explore.
 If SeamlessRDP is enabled this is the application which is started in seamless mode.
 .TP
-.BR "-c <directory>"
-The initial working directory for the user.  Often used in combination with -s
+.BR "\-c <directory>"
+The initial working directory for the user.  Often used in combination with \-s
 to set up a fixed login environment.
 .TP
-.BR "-p <password>"
+.BR "\-p <password>"
 The password to authenticate with.  Note that this may have no effect if
 "Always prompt for password" is enabled on the server.  WARNING: if you specify
 a password on the command line it may be visible to other users when they use
-tools like ps.  Use -p - to make rdesktop request a password at startup (from
+tools like ps.  Use \-p \- to make rdesktop request a password at startup (from
 standard input).
 .TP
-.BR "-n <hostname>"
+.BR "\-n <hostname>"
 Client hostname.  Normally rdesktop automatically obtains the hostname of the
 client.
 .TP
-.BR "-k <keyboard-map>"
+.BR "\-k <keyboard-map>"
 Keyboard layout to emulate.  This requires a corresponding keymap file to be
 installed.  The standard keymaps provided with rdesktop follow the RFC1766
 naming scheme: a language code followed by a country code if necessary - e.g.
-en-us, en-gb, de, fr, sv, etc.
+en\-us, en\-gb, de, fr, sv, etc.
 
 The default keyboard map depends on the current locale (LC_* and LANG
 environment variables). If the current locale is unknown, the default
-keyboard map is en-us (a US English keyboard).
+keyboard map is en\-us (a US English keyboard).
 
 The keyboard maps are file names, which means that they are case
 sensitive. The standard keymaps are all in lowercase.
@@ -62,12 +62,12 @@ codes using an internal mapping method. This method only supports the
 basic alphanumeric keys and may not work properly on all platforms
 so its use is discouraged.
 .TP
-.BR "-g <geometry>"
+.BR "\-g <geometry>"
 Desktop geometry (WxH[@DPI][+X[+Y]]). If geometry is the special word
 "workarea", the geometry will be fetched from the extended window
 manager hints property _NET_WORKAREA, from the root window. The
 geometry can also be specified as a percentage of the whole screen,
-e.g. "-g 80%", "-g 80%x70%".
+e.g. "\-g 80%", "\-g 80%x70%".
 
 If the specified geometry depends on the screen size, and the screen
 size is changed, rdesktop will automatically reconnect using the new
@@ -80,27 +80,27 @@ be readable. Windows currently accepts values from 96 to 480.
 
 Offset placement of window is optional. Starting point is upper left corner of screen.
 Window manager might push into visible area, if a panel would be covered.
-The schema is "-g <value>+<xoff>+<yoff>, f.e. "-g 30%+200+600".
+The schema is "\-g <value>+<xoff>+<yoff>, f.e. "\-g 30%+200+600".
 .TP
-.BR "-i"
+.BR "\-i"
 Use password as smartcard pin. If a valid user certificate is matched in smart card
-reader the password passed with \f-p\fR argument is used as pin for the smart card.
-This feature also requires that smart card redirection is used using \f-r scard\fR argument.
+reader the password passed with \f\-p\fR argument is used as pin for the smart card.
+This feature also requires that smart card redirection is used using \f\-r scard\fR argument.
 .TP
-.BR "-f"
+.BR "\-f"
 Enable fullscreen mode.  This overrides the window manager and causes the
 rdesktop window to fully cover the current screen.  Fullscreen mode can be
 toggled at any time using Ctrl-Alt-Enter.
 .TP
-.BR "-b"
+.BR "\-b"
 Force the server to send screen updates as bitmaps rather than using
 higher-level drawing operations.
 .TP
-.BR "-t"
+.BR "\-t"
 Disable use of remote control. This will disable features like seamless connection
 sharing.
 .TP
-.BR "-A <seamlessrdpshell>"
+.BR "\-A <seamlessrdpshell>"
 Enable SeamlessRDP by specifying the path to seamless rdp shell. 
 In this mode, rdesktop creates a X11 window for each window on the server side. 
 This mode requires the SeamlessRDP server side component, which is available from 
@@ -109,81 +109,81 @@ This mode requires the SeamlessRDP server side component, which is available fro
 When using this option, you should normally specify a startup shell which
 launches the desired application through SeamlessRDP. 
 
-Example: rdesktop -A 'c:\\seamlessrdp\\seamlessrdpshell.exe' -s 'notepad' mywts.domain.com
+Example: rdesktop \-A 'c:\\seamlessrdp\\seamlessrdpshell.exe' \-s 'notepad' mywts.domain.com
 
 Any subsequential call to the above command line example will make use of the seamless 
 connection sharing feature which spawns another notepad in the current connection to the
 specified server and then exit.
 
 .TP
-.BR "-V <tls version>"
+.BR "\-V <tls version>"
 Set the Transport Level Security (also known as SSL) Version used.
 Should be one of the following values: 1.0, 1.1, 1.2. By default all
 versions are supported.
 .TP
-.BR "-B"
+.BR "\-B"
 Use the BackingStore of the Xserver instead of the integrated one in
 rdesktop.
 .TP
-.BR "-e"
+.BR "\-e"
 Disable encryption.  This option is only needed (and will only work) if you
 have a French version of NT TSE.
 .TP
-.BR "-E"
+.BR "\-E"
 Disable encryption from client to server.  This sends an encrypted login packet,
 but everything after this is unencrypted (including interactive logins).
 .TP
-.BR "-m"
+.BR "\-m"
 Do not send mouse motion events.  This saves bandwidth, although some Windows
 applications may rely on receiving mouse motion.
 .TP
-.BR "-M"
+.BR "\-M"
 Use local X cursor inherited from window manager instead of server cursor. This
-is mostly useful with -m, but is also useful if the server is sending bogus
+is mostly useful with \-m, but is also useful if the server is sending bogus
 mouse cursors.
 .TP
-.BR "-C"
+.BR "\-C"
 Use private colourmap.  This will improve colour accuracy on an 8-bit display,
 but rdesktop will appear in false colour when not focused.
 .TP
-.BR "-D"
+.BR "\-D"
 Hide window manager decorations, by using MWM hints. 
 .TP
-.BR "-K"
+.BR "\-K"
 Do not override window manager key bindings.  By default rdesktop attempts
 to grab all keyboard input when it is in focus.
 .TP
-.BR "-S <button size>"
+.BR "\-S <button size>"
 Enable single application mode. This option can be used when running a
-single, maximized application (via -s). When the minimize button of
+single, maximized application (via \-s). When the minimize button of
 the windows application is pressed, the rdesktop window is minimized
 instead of the remote application. The maximize/restore button is
 disabled. For this to work, you must specify the correct button
 size, in pixels. The special word "standard" means 18 pixels. 
 .TP
-.BR "-T <title>"
+.BR "\-T <title>"
 Sets the window title. The title must be specified using an UTF-8 string. 
 .TP
-.BR "-N"
+.BR "\-N"
 Enable numlock synchronization between the Xserver and the remote RDP
 session.  This is useful with applications that looks at the numlock
 state, but might cause problems with some Xservers like Xvnc. 
 .TP
-.BR "-X <windowid>"
+.BR "\-X <windowid>"
 Embed rdesktop-window in another window. The windowid is expected to
 be decimal or hexadecimal (prefixed by 0x).
 .TP
-.BR "-a <bpp>"
+.BR "\-a <bpp>"
 Sets the colour depth for the connection (8, 15, 16, 24 or 32).
 More than 8 bpp are only supported when connecting to Windows XP
 (up to 16 bpp) or newer.  Note that the colour depth may also be
 limited by the server configuration. The default value is the depth 
 of the root window. 
 .TP
-.BR "-z"
+.BR "\-z"
 Enable compression of the RDP datastream.
 .TP
-.BR "-x <experience>"
+.BR "\-x <experience>"
 Changes default bandwidth performance behaviour for RDP5. By default only
 theming is enabled, and all other options are disabled (corresponding
 to modem (56 Kbps)). Setting experience to b[roadband] enables menu
@@ -192,21 +192,21 @@ also enable the desktop wallpaper. Setting experience to m[odem]
 disables all (including themes). Experience can also be a hexadecimal
 number containing the flags.
 .TP
-.BR "-P"
+.BR "\-P"
 Enable caching of bitmaps to disk (persistent bitmap caching). This generally
 improves performance (especially on low bandwidth connections) and reduces
 network traffic at the cost of slightly longer startup and some disk space.
 (10MB for 8-bit colour, 20MB for 15/16-bit colour, 30MB for 24-bit colour
 and 40MB for 32-bit colour sessions)
 .TP
-.BR "-r <device>"
+.BR "\-r <device>"
 Enable redirection of the specified device on the client, such
 that it appears on the server. Note that the allowed
 redirections may be restricted by the server configuration.
 
 Following devices are currently supported:
 .TP
-.BR "-r comport:<comport>=<device>,..."
+.BR "\-r comport:<comport>=<device>,..."
 Redirects serial devices on your client to the
 server. Note that if you need to change any settings on the serial device(s),
 do so with an appropriate tool before starting rdesktop. In most
@@ -214,35 +214,35 @@ OSes you would use stty. Bidirectional/Read support requires Windows XP or newer
 In Windows 2000 it will create a port, but it's not seamless, most
 shell programs will not work with it.
 .TP
-.BR "-r disk:<sharename>=<path>,..."
+.BR "\-r disk:<sharename>=<path>,..."
 Redirects a path to the share \\\\tsclient\\<sharename> on the server
 (requires Windows XP or newer). The share name is limited to 8
 characters. 
 .TP
-.BR "-r lptport:<lptport>=<device>,..."
+.BR "\-r lptport:<lptport>=<device>,..."
 Redirects parallel devices on your client to the server.
 Bidirectional/Read support requires Windows XP or newer. In Windows 2000
 it will create a port, but it's not seamless, most shell programs will not work with
 it.
 .TP
-.BR "-r printer:<printername>[=<driver>],..."
+.BR "\-r printer:<printername>[=<driver>],..."
 Redirects a printer queue on the client to the server. The <printername>
 is the name of the queue in your local system. <driver> defaults to a
 simple PS-driver unless you specify one. Keep in mind that you need a
 100% match in the server environment, or the driver will fail. The first
 printer on the command line will be set as your default printer.
 .TP
-.BR "-r sound:[local|off|remote]"
+.BR "\-r sound:[local|off|remote]"
 Redirects sound generated on the server to the client. "remote" only has
-any effect when you connect to the console with the -0 option. (Requires
+any effect when you connect to the console with the \-0 option. (Requires
 Windows XP or newer).
 .TP
-.BR "-r lspci"
+.BR "\-r lspci"
 Activates the lspci channel, which allows the server to enumerate the
 clients PCI devices. See the file lspci-channel.txt in the
 documentation for more information.
 .TP
-.BR "-r scard[:<Scard Name>=<Alias Name>[;<Vendor Name>][,...]]"
+.BR "\-r scard[:<Scard Name>=<Alias Name>[;<Vendor Name>][,...]]"
 Enables redirection of one or more smart-cards. You can provide
 static name binding between GNU/Linux and Windows. To do this you
 can use optional parameters as described: <Scard Name> - device name in
@@ -250,41 +250,41 @@ GNU/Linux and UNIX environment, <Alias Name> - device name shown in Windows envi
 <Vendor Name> - optional device vendor name. For list of examples run
 rdesktop without parameters.
 .TP
-.BR "-r clipboard:[off|PRIMARYCLIPBOARD|CLIPBOARD]"
+.BR "\-r clipboard:[off|PRIMARYCLIPBOARD|CLIPBOARD]"
 Enable clipboard redirection. 'PRIMARYCLIPBOARD' looks at both PRIMARY and
 CLIPBOARD when sending data to server. 'CLIPBOARD' looks at only 'CLIPBOARD'.
 .TP
-.BR "-0"
+.BR "\-0"
 Attach to the console of the server (requires Windows Server 2003
 or newer).
 .TP
-.BR "-4"
+.BR "\-4"
 Use RDP version 4.
 .TP
-.BR "-5"
+.BR "\-5"
 Use RDP version 5 (default).
 .TP
-.BR "-v"
+.BR "\-v"
 Enable verbose output
 .PP
 
 .SH "CredSSP Smartcard options"
 .TP
-.BR "--sc-csp-name <name>"
+.BR "\-\-sc\-csp\-name <name>"
 Specify the CSP (Crypto Service Provider) to use on the windows side for the smartcard
 authentication. CSP is the driver for your smartcard and it seems like this is required
 to be specified for CredSSP authentication. For Swedish NetID the following CSP name is
 used; "Net iD - CSP".
 .TP
-.BR "--sc-container-name <name>"
+.BR "\-\-sc\-container\-name <name>"
 Specify the container name, usually this is the username for default container and it seems
 like this is required to be specified for CredSSP authentication.
 .TP
-.BR "--sc-reader-name <name>"
+.BR "\-\-sc\-reader\-name <name>"
 Specify the reader name to be used to prevent the pin code being sent to wrong card if there
 are several readers.
 .TP
-.BR "--sc-card-name <name>"
+.BR "\-\-sc\-card\-name <name>"
 Specify the card name for example; "Telia EID IP5a".
 .PP
 


### PR DESCRIPTION
Escape dashes/hyphens in man page options so that they can be copied and pasted, searched for, etc.