### PR TITLE
Add files via upload

### DIFF
--- a/ewmhints.c
+++ b/ewmhints.c
@@ -102,7 +102,7 @@ get_property_value(Window wnd, char *propname, long max_length,
    Get current desktop number
    Returns -1 on error
 */
-static int
+int
 get_current_desktop(void)
 {
 	unsigned long nitems_return;

--- a/proto.h
+++ b/proto.h
@@ -83,6 +83,7 @@ RD_NTSTATUS disk_query_directory(RD_NTHANDLE handle, uint32 info_class, char *pa
 int mppc_expand(uint8 * data, uint32 clen, uint8 ctype, uint32 * roff, uint32 * rlen);
 /* ewmhints.c */
 int get_current_workarea(uint32 * x, uint32 * y, uint32 * width, uint32 * height);
+int get_current_desktop(void);
 void ewmh_init(void);
 /* iso.c */
 STREAM iso_init(int length);

--- a/rdesktop.c
+++ b/rdesktop.c
@@ -101,6 +101,7 @@ RD_BOOL g_desktop_save = True;	/* desktop save order */
 RD_BOOL g_polygon_ellipse_orders = True;	/* polygon / ellipse orders */
 RD_BOOL g_fullscreen = False;
 RD_BOOL g_grab_keyboard = True;
+RD_BOOL g_grab_keyboard_except_workspace = False;
 RD_BOOL g_local_cursor = False;
 RD_BOOL g_hide_decorations = False;
 RDP_VERSION g_rdp_version = RDP_V5;	/* Default to version 5 */
@@ -193,6 +194,7 @@ usage(char *program)
 	fprintf(stderr, "   -M: use local mouse cursor\n");
 	fprintf(stderr, "   -C: use private colour map\n");
 	fprintf(stderr, "   -D: hide window manager decorations\n");
+	fprintf(stderr, "   -G: grab keyboard (release grab on CTRL+ALT+LEFT/RIGHT)\n");
 	fprintf(stderr, "   -K: keep window manager key bindings\n");
 	fprintf(stderr, "   -S: caption button size (single application mode)\n");
 	fprintf(stderr, "   -T: window title\n");
@@ -820,7 +822,7 @@ main(int argc, char *argv[])
 	g_num_devices = 0;
 
 	while ((c = getopt(argc, argv,
-			   "A:V:u:L:d:s:c:p:n:k:g:o:fbBeEitmMzCDKS:T:NX:a:x:Pr:045vh?")) != -1)
+			   "A:V:u:L:d:s:c:p:n:k:g:o:fbBeEitmMzCDKGS:T:NX:a:x:Pr:045vh?")) != -1)
 	{
 		switch (c)
 		{
@@ -934,6 +936,11 @@ main(int argc, char *argv[])
 
 			case 'K':
 				g_grab_keyboard = False;
+				break;
+
+			case 'G':
+				g_grab_keyboard_except_workspace = True;
+				g_grab_keyboard = True;
 				break;
 
 			case 'S':


### PR DESCRIPTION
feat: enhance fullscreen functionality with monitor selection and workspace switching

This commit introduces two key improvements to rdesktop's fullscreen functionality:

1. **Monitor-specific fullscreen support**
   - Enhanced `-f` flag to accept optional monitor number: `-f[N]`
   - `-f` without N: fullscreen across all monitors (default behavior)  
   - `-fN`: fullscreen on specific monitor N (e.g., `-f0`, `-f1`, `-f2`)
   - Added `g_fullscreen_monitor` variable to track selected monitor

2. **Workspace switching with keyboard grab**
   - Added new `-G` command line flag that enables `g_grab_keyboard_except_workspace` mode
   - Implemented workspace/virtual desktop detection using EWMH hints:
     - `get_current_desktop()` to query `_NET_CURRENT_DESKTOP`
     - `get_current_workarea()` to query `_NET_WORKAREA` for the current desktop
   - Modified keyboard event handling to detect and pass through workspace switching: - Ctrl+Alt+[1-9] key combinations are intercepted - Keyboard is ungrabbed temporarily during workspace switch - `_NET_CURRENT_DESKTOP` message is sent to the window manager - Keyboard is re-grabbed after the switch
   - Updated input mask handling to support the new grab mode
